### PR TITLE
Switched out logic for html tag to className syntax for react

### DIFF
--- a/client/src/components/Comments.jsx
+++ b/client/src/components/Comments.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 const Comments = (props) => (
   <div>
-    <ul class="comment">
+    <ul className="comment">
     	{props.comments.map((comment) => {
-    	  return <div key="comment.idcomments"><li class="comment">{comment.comment}</li></div>	
+    	  return <div key="comment.idcomments"><li className="comment">{comment.comment}</li></div>	
     	})}
     </ul>
   </div>


### PR DESCRIPTION
There was an error coming from having the UL and LI items use the classic html class attribute